### PR TITLE
Dispose of test fixture

### DIFF
--- a/src/ChristopherBriddock.Service.Identity.Tests/ChristopherBriddock.Service.Identity.Tests.csproj
+++ b/src/ChristopherBriddock.Service.Identity.Tests/ChristopherBriddock.Service.Identity.Tests.csproj
@@ -17,7 +17,10 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="6.0.1" />
   </ItemGroup>
 

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/AccountPurgeBackgroundServiceTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/AccountPurgeBackgroundServiceTests.cs
@@ -33,6 +33,8 @@ public class AccountPurgeBackgroundServiceTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/AuthorizeEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/AuthorizeEndpointTests.cs
@@ -16,6 +16,8 @@ public class AuthorizeEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/ConfirmEmailEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/ConfirmEmailEndpointTests.cs
@@ -16,6 +16,8 @@ public class ConfirmEmailEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/DeleteAccountEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/DeleteAccountEndpointTests.cs
@@ -20,6 +20,8 @@ public class DeleteAccountEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/LogoutEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/LogoutEndpointTests.cs
@@ -18,6 +18,8 @@ public class LogoutEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/RefreshEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/RefreshEndpointTests.cs
@@ -17,10 +17,12 @@ namespace ChristopherBriddock.Service.Identity.Tests.IntegrationTests
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            _fixture.OneTimeTearDown();
-        }
+    public void OneTimeTearDown()
+    {
+        _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
+    }
 
         [Test]
         public async Task RefreshEndpoint_Returns401_WhenInvalidTokenIsUsed()

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/RegisterEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/RegisterEndpointTests.cs
@@ -16,6 +16,8 @@ public class RegisterEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/ResetPasswordEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/ResetPasswordEndpointTests.cs
@@ -18,6 +18,8 @@ public class ResetPasswordEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/SendTokenEmailEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/SendTokenEmailEndpointTests.cs
@@ -18,6 +18,8 @@ public class SendTokenEmailEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     public static IEnumerable<object[]> GetTokenType()

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TokenEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TokenEndpointTests.cs
@@ -22,6 +22,8 @@ public class TokenEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
     private HttpClient CreateClientWithMocks(IConfiguration configuration, IJsonWebTokenProvider tokenProvider, ClaimsPrincipal user)
     {

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorAuthorizeEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorAuthorizeEndpointTests.cs
@@ -16,6 +16,8 @@ public class TwoFactorAuthorizeEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorManageEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorManageEndpointTests.cs
@@ -18,6 +18,8 @@ public class TwoFactorManageEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
 

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorRecoveryCodesEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorRecoveryCodesEndpointTests.cs
@@ -15,10 +15,12 @@ public class TwoFactorRecoveryCodesEndpointTests
         }
 
         [OneTimeTearDown]
-        public void OneTimeTearDown()
-        {
-            _fixture.OneTimeTearDown();
-        }
+    public void OneTimeTearDown()
+    {
+        _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
+    }
 
     [Test]
     public async Task TwoFactorRecoveryCodesEndpoint_Returns200OK_WhenRecoveryCodesAreRequested()

--- a/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorRecoveryCodesRedeemEndpointTests.cs
+++ b/src/ChristopherBriddock.Service.Identity.Tests/IntegrationTests/TwoFactorRecoveryCodesRedeemEndpointTests.cs
@@ -15,6 +15,8 @@ public class TwoFactorRecoveryCodesRedeemEndpointTests
     public void OneTimeTearDown()
     {
         _fixture.OneTimeTearDown();
+        _fixture.Dispose();
+        _fixture = null!;
     }
 
     [Test]


### PR DESCRIPTION
Correctly dispose of test fixture, so newest NUnit.Analyzers work properly.